### PR TITLE
add rainbowifier

### DIFF
--- a/src/main/java/at/haha007/edenclient/EdenClient.java
+++ b/src/main/java/at/haha007/edenclient/EdenClient.java
@@ -27,6 +27,7 @@ public class EdenClient implements ClientModInitializer {
         new AntiStrip();
         new MessageIgnorer();
         new AutoSheer();
+        new Rainbowifier();
 
 //        CommandManager.register(new Command(CommandManager::onCommand), "commands", "cmds", "eden");
     }

--- a/src/main/java/at/haha007/edenclient/mods/MessageIgnorer.java
+++ b/src/main/java/at/haha007/edenclient/mods/MessageIgnorer.java
@@ -4,6 +4,7 @@ import at.haha007.edenclient.callbacks.AddChatMessageCallback;
 import at.haha007.edenclient.callbacks.ConfigLoadCallback;
 import at.haha007.edenclient.callbacks.ConfigSaveCallback;
 import at.haha007.edenclient.utils.PlayerUtils;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import net.minecraft.client.network.ClientCommandSource;
@@ -11,7 +12,7 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.nbt.NbtString;
-import net.minecraft.text.LiteralText;
+import net.minecraft.text.*;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Formatting;
 
@@ -66,26 +67,38 @@ public class MessageIgnorer {
     private void registerCommand(String cmd) {
         LiteralArgumentBuilder<ClientCommandSource> node = literal(cmd);
         node.then(literal("toggle").executes(c -> {
-            PlayerUtils.sendModMessage(new LiteralText((enabled = !enabled) ? "Message ignoring enabled" : "Message ignoring disabled").formatted(Formatting.GOLD));
+            String msg = (enabled = !enabled) ? "Message ignoring enabled" : "Message ignoring disabled";
+            PlayerUtils.sendModMessage(new LiteralText(msg).formatted(Formatting.GOLD));
             return 1;
         }));
         node.then(literal("add").then(argument("regex", StringArgumentType.greedyString()).executes(c -> {
             String im = c.getArgument("regex", String.class);
             if (!isValidRegex(im)) {
                 PlayerUtils.sendModMessage(new LiteralText("Invalid pattern syntax").formatted(Formatting.GOLD));
-                return 1;
+                return -1;
+            }
+            if (regex.contains(im)) {
+                PlayerUtils.sendModMessage(new LiteralText("Already ignoring this pattern").formatted(Formatting.GOLD));
+                return -1;
             }
             regex.add(im);
             PlayerUtils.sendModMessage(new LiteralText("Ignoring messages matching " + im).formatted(Formatting.GOLD));
             return 1;
         })));
-        node.then(literal("remove").then(argument("regex", StringArgumentType.greedyString()).executes(c -> {
-            String im = c.getArgument("regex", String.class);
-            if (regex.remove(im)) {
-                PlayerUtils.sendModMessage(new LiteralText("Removed ignored message").formatted(Formatting.GOLD));
-            } else {
-                PlayerUtils.sendModMessage(new LiteralText("Could not find message: " + im).formatted(Formatting.GOLD));
+        node.then(literal("remove").then(argument("index", IntegerArgumentType.integer(1)).executes(c -> {
+            int index = c.getArgument("index", Integer.class) - 1;
+            if (index >= regex.size()) {
+                MutableText prefix = new LiteralText("Index out of bounds. Use ").formatted(Formatting.GOLD);
+                MutableText suggestion = new LiteralText("/" + cmd + " list").setStyle(Style.EMPTY.
+                        withColor(Formatting.AQUA).
+                        withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new LiteralText("click to execute"))).
+                        withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/" + cmd + " list")));
+                MutableText suffix = new LiteralText(" to see available indices.").formatted(Formatting.GOLD);
+                PlayerUtils.sendModMessage(prefix.append(suggestion).append(suffix));
+                return -1;
             }
+            PlayerUtils.sendModMessage(new LiteralText("Removed: ").formatted(Formatting.GOLD).
+                    append(new LiteralText(regex.remove(index)).formatted(Formatting.AQUA)));
             return 1;
         })));
         node.then(literal("list").executes(c -> {
@@ -95,7 +108,9 @@ public class MessageIgnorer {
             }
             PlayerUtils.sendModMessage(new LiteralText("List of ignored message-regexes:").formatted(Formatting.GOLD));
             for (int i = 0; i < regex.size(); i++) {
-                PlayerUtils.sendModMessage(new LiteralText("[" + (i + 1) + "] " + regex.get(i)).formatted(Formatting.GOLD));
+                MutableText txt = new LiteralText(regex.get(i)).formatted(Formatting.AQUA);
+                MutableText prefix = new LiteralText("[" + (i + 1) + "] ").formatted(Formatting.GOLD);
+                PlayerUtils.sendModMessage(prefix.append(txt));
             }
             return 1;
         }));

--- a/src/main/java/at/haha007/edenclient/mods/NbtInfo.java
+++ b/src/main/java/at/haha007/edenclient/mods/NbtInfo.java
@@ -7,6 +7,7 @@ import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.visitor.NbtTextFormatter;
 import net.minecraft.text.LiteralText;
+import net.minecraft.util.Formatting;
 
 import static at.haha007.edenclient.utils.PlayerUtils.sendModMessage;
 
@@ -19,7 +20,7 @@ public class NbtInfo {
             PlayerInventory inv = player.getInventory();
             ItemStack stack = inv.getMainHandStack();
             if (stack.isEmpty()) {
-                sendModMessage(new LiteralText("Item in die Hand!"));
+                sendModMessage(new LiteralText("Item in die Hand!").formatted(Formatting.GOLD));
             } else {
                 sendModMessage(new NbtTextFormatter("", 1).apply(stack.getOrCreateTag()));
             }

--- a/src/main/java/at/haha007/edenclient/mods/Rainbowifier.java
+++ b/src/main/java/at/haha007/edenclient/mods/Rainbowifier.java
@@ -1,0 +1,212 @@
+package at.haha007.edenclient.mods;
+
+import at.haha007.edenclient.callbacks.ConfigLoadCallback;
+import at.haha007.edenclient.callbacks.ConfigSaveCallback;
+import com.mojang.brigadier.arguments.DoubleArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientCommandSource;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.text.LiteralText;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Formatting;
+
+import java.util.List;
+
+import static at.haha007.edenclient.command.CommandManager.*;
+import static at.haha007.edenclient.utils.PlayerUtils.sendModMessage;
+
+
+public class Rainbowifier {
+    private final List<Character> simpleRainbowColors = List.of('c', '6', 'e', 'a', 'b', '3', 'd', '5', 'd', '3', 'b', 'a', 'e', '6');
+    private double freq;
+
+    public Rainbowifier() {
+        registerCommand();
+        ConfigSaveCallback.EVENT.register(this::onSave);
+        ConfigLoadCallback.EVENT.register(this::onLoad);
+    }
+
+    private ActionResult onLoad(NbtCompound nbtCompound) {
+        NbtCompound rainbowTag = nbtCompound.getCompound("rainbowify");
+
+        if (rainbowTag != null) {
+            if (rainbowTag.contains("freq"))
+                this.freq = rainbowTag.getDouble("freq");
+            else
+                this.freq = 0.3;
+        }
+
+        return ActionResult.PASS;
+    }
+
+    private ActionResult onSave(NbtCompound nbtCompound) {
+        NbtCompound rainbowTag = new NbtCompound();
+        rainbowTag.putDouble("freq", this.freq);
+        nbtCompound.put("rainbowify", rainbowTag);
+
+        return ActionResult.PASS;
+    }
+
+    private void registerCommand() {
+        LiteralArgumentBuilder<ClientCommandSource> node = literal("rainbowify");
+
+        node.then(literal("fancy").then(argument("input", StringArgumentType.greedyString()).executes(c -> {
+            String input = c.getArgument("input", String.class);
+
+            String message = rainbowifyMessageFancy(input);
+
+            if (message.length() >= 256) {
+                sendModMessage(new LiteralText("Deine Nachricht ist zu lang. Es werden nur bis zu 25 Zeichen (mit einigen Leerzeichen) im Rainbowifier-Fancy unterstützt.").formatted(Formatting.GOLD));
+                return 0;
+            }
+            ClientPlayerEntity entityPlayer = MinecraftClient.getInstance().player;
+
+            if (entityPlayer != null) {
+                entityPlayer.sendChatMessage(rainbowifyMessageFancy(input));
+            }
+
+            return 1;
+        })));
+
+        node.then(literal("simple").then(argument("input", StringArgumentType.greedyString()).executes(c -> {
+            String input = c.getArgument("input", String.class);
+
+            String message = rainbowifyMessageSimple(input);
+
+            if (message.length() >= 256) {
+                sendModMessage(new LiteralText("Deine Nachricht ist zu lang. Es werden nur bis zu 80 Zeichen (mit einigen Leerzeichen) im Rainbowifier-Simple unterstützt.").formatted(Formatting.GOLD));
+                return 0;
+            }
+            ClientPlayerEntity entityPlayer = MinecraftClient.getInstance().player;
+
+            if (entityPlayer != null) {
+                entityPlayer.sendChatMessage(rainbowifyMessageSimple(input));
+            }
+
+            return 1;
+        })));
+
+        node.then(literal("msg").then(argument("player", StringArgumentType.word()).then(argument("message", StringArgumentType.greedyString()).executes(c -> {
+            String player = c.getArgument("player", String.class);
+            if (!player.matches("[a-zA-Z0-9_]{1,16}")) {
+                sendModMessage(new LiteralText("Der Spielername, den du eingegeben hast, ist ungültig.").formatted(Formatting.GOLD));
+                return 0;
+            }
+
+            String originalMessage = c.getArgument("message", String.class);
+
+            String message = "/msg " + player + " " + rainbowifyMessageFancy(originalMessage);
+
+            if (message.length() >= 256) {
+                message = "/msg " + player + " " + rainbowifyMessageSimple(originalMessage);
+                if (message.length() >= 256) {
+                    sendModMessage(new LiteralText("Deine Nachricht ist zu lang. Es werden nur bis zu 25 Zeichen im Rainbowifier-Fancy und 80 Zeichen im Rainbowifier-Simple unterstützt.").formatted(Formatting.GOLD));
+                    return 0;
+                }
+            }
+
+            ClientPlayerEntity entityPlayer = MinecraftClient.getInstance().player;
+
+            if (entityPlayer != null) {
+                entityPlayer.sendChatMessage(message);
+            }
+
+            return 1;
+        }))));
+
+        node.then(literal("auto").then(argument("input", StringArgumentType.greedyString()).executes(c -> {
+            String input = c.getArgument("input", String.class);
+            boolean simple = false;
+
+            String message = rainbowifyMessageFancy(input);
+
+            if (message.length() >= 256) {
+                simple = true;
+                message = rainbowifyMessageSimple(input);
+                if (message.length() >= 256) {
+                    sendModMessage(new LiteralText("Deine Nachricht ist zu lang. Es werden nur bis zu 80 Zeichen (mit einigen Leerzeichen) im Rainbowifier-Simple unterstützt.").formatted(Formatting.GOLD));
+                    return 0;
+                }
+            }
+
+            ClientPlayerEntity entityPlayer = MinecraftClient.getInstance().player;
+
+            if (entityPlayer != null) {
+                entityPlayer.sendChatMessage(message);
+                sendModMessage("Für deine Nachricht wurde der " + (simple ? "simple" : "fancy") + " Modus ausgewählt");
+            }
+
+            return 1;
+        })));
+
+        node.then(literal("freq").then(argument("frequency", DoubleArgumentType.doubleArg(0.1, 1.0)).executes(c -> {
+            this.freq = c.getArgument("frequency", Double.class);
+            sendModMessage(new LiteralText("Frequency für Rainbowify-Fancy wurde auf " + freq + " gesetzt.").formatted(Formatting.GOLD));
+
+            return 1;
+        })));
+
+        node.executes(c -> {
+            sendDebugMessage();
+            return 1;
+        });
+
+        register(node);
+    }
+
+    private String rainbowifyMessageFancy(String input) {
+        StringBuilder rainbow = new StringBuilder();
+
+        for (int i = 0; i < input.length(); i++) {
+            char character = input.charAt(i);
+            int[] color = getFancyRainbowColorAtIndex(i);
+            if (character == ' ') {
+                rainbow.append(' ');
+                continue;
+            }
+            rainbow.append(String.format("&#%02X%02X%02X", color[0], color[1], color[2])).append(character);
+        }
+
+        return rainbow.toString();
+    }
+
+    private String rainbowifyMessageSimple(String input) {
+        StringBuilder rainbow = new StringBuilder();
+        int length = input.length();
+
+        for (int i = 0; i < length; i++) {
+            char character = input.charAt(i);
+            String color = getSimpleRainbowColorAtIndex(i);
+
+            if (character == ' ') {
+                rainbow.append(' ');
+                continue;
+            }
+
+            rainbow.append(color).append(character);
+        }
+
+        return rainbow.toString();
+    }
+
+    private int[] getFancyRainbowColorAtIndex(int index) {
+        int[] color = new int[3];
+
+        color[0] = (int) (Math.sin(freq * index) * 127 + 128);
+        color[1] = (int) (Math.sin(freq * index + 2) * 127 + 128);
+        color[2] = (int) (Math.sin(freq * index + 4) * 127 + 128);
+
+        return color;
+    }
+
+    private String getSimpleRainbowColorAtIndex(int input) {
+        return "&" + this.simpleRainbowColors.get(input % this.simpleRainbowColors.size());
+    }
+
+    private void sendDebugMessage() {
+        sendModMessage(new LiteralText("/rainbowify [simple, fancy, freq, auto, msg <recipient message>]").formatted(Formatting.GOLD));
+    }
+}


### PR DESCRIPTION
* Added option to remove specific regexes in MessageIgnorer by index (index of list)

* Removed option to remove regexes without correct index

* Fix Formatting in NbtInfo

* Add option to "rainbowify" messages

* Improve Rainbowifier for better length check

* Use regex to be able to send private messages. To be reworked in the future

* Revert regex by adding specific sub command for sending private messages. Also add "auto" command which chooses if fancy or simple mode is appropriate for this specific global message.

* Fixed look of simpleRainbowColorsExtended

* Fix debugMessage in Rainbowifier

* Remove unnecessary color list

* Update MessageIgnorer.java

Co-authored-by: Haha007 <nichtechtanonym@gmail.com>